### PR TITLE
fix(formula): default formula ref angular  name(scope): subject

### DIFF
--- a/Engine.js
+++ b/Engine.js
@@ -46,7 +46,7 @@ function loadConfig (path) {
 
 function format (answers, formulaString) {
   // TODO: Use template engine
-  let formula = formulaString || '${title} ${emoji} ${scope}: ${subject}'
+  let formula = formulaString || '${name}${scope}: ${subject}'
   let target = formula.match(/\${(.+?)}/g)
   target.map(string => {
     const key = string.match(/\${(.+?)}/)[1]

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict'
-var engine = require('./engine')
+var engine = require('./Engine')
 module.exports = engine()


### PR DESCRIPTION
I think angular commit format as default,
the formula should be '${name}${scope}: ${subject}'
see: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format

```md
<type>(<scope>): <subject>
<BLANK LINE>
<body>
<BLANK LINE>
<footer>
```

about emoji should be custom setting formula.